### PR TITLE
Fix some signal signatures, remove extra trailing whitespace

### DIFF
--- a/StartingGTK_C/grid01.c
+++ b/StartingGTK_C/grid01.c
@@ -3,7 +3,7 @@
 int main (int argc, char *argv[])
 {
     GtkWidget *win, *grid, *b1, *b2, *cb1, *cb2, *cb3, *cb4;
-    
+
     gtk_init (&argc, &argv);
     win = gtk_window_new(GTK_WINDOW_TOPLEVEL);
     gtk_window_set_title (GTK_WINDOW (win), "Language Selector");
@@ -11,7 +11,7 @@ int main (int argc, char *argv[])
     gtk_container_set_border_width (GTK_CONTAINER (win), 10);
 
     grid = gtk_grid_new ();
-    
+
     b1 = gtk_button_new_with_label ("Quit");
     g_signal_connect (b1, "clicked", G_CALLBACK (gtk_main_quit), NULL);
 
@@ -33,7 +33,7 @@ int main (int argc, char *argv[])
 
     g_signal_connect (win, "destroy", G_CALLBACK (gtk_main_quit), NULL);
     gtk_widget_show_all(win);
-    
+
     gtk_main();
     return 0;
 }

--- a/StartingGTK_C/window04.c
+++ b/StartingGTK_C/window04.c
@@ -1,6 +1,6 @@
 #include <gtk/gtk.h>
 
-static void on_button_clicked (GtkWidget* widget, gpointer data)
+static void on_button_clicked (GtkButton *button, gpointer user_data)
 {
     g_print ("Welcome to APISTRAT\n");
 }

--- a/StartingGTK_C/window05.c
+++ b/StartingGTK_C/window05.c
@@ -1,6 +1,6 @@
 #include <gtk/gtk.h>
 
-static void on_button_clicked (GtkWidget* widget, gpointer data)
+static void on_button_clicked (GtkButton *button, gpointer user_data)
 {
     g_print ("Welcome to APISTRAT \n");
 }

--- a/StartingGTK_C/window06.c
+++ b/StartingGTK_C/window06.c
@@ -1,8 +1,9 @@
 #include <gtk/gtk.h>
 
-static void on_button_clicked (GtkWidget* widget, gpointer data)
+static void on_button_clicked (GtkButton *button, gpointer user_data)
 {
-    gtk_label_set_text (GTK_LABEL (data), "Welcome to APISTRAT");
+    GtkWidget *label = user_data;
+    gtk_label_set_text (GTK_LABEL (label), "Welcome to APISTRAT");
 }
 
 int main (int argc, char* argv[])
@@ -17,7 +18,7 @@ int main (int argc, char* argv[])
 
     label = gtk_label_new (NULL);
     button = gtk_button_new_with_label ("Click me");
-      
+
     box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
     gtk_box_pack_start (GTK_BOX (box), button, TRUE, TRUE, 0);
     gtk_box_pack_start (GTK_BOX (box), label, TRUE, TRUE, 0);

--- a/StartingGTK_C/window07.c
+++ b/StartingGTK_C/window07.c
@@ -1,8 +1,9 @@
 #include <gtk/gtk.h>
 
-static void on_button_clicked (GtkWidget* widget, gpointer data)
+static void on_button_clicked (GtkButton *button, gpointer user_data)
 {
-    gtk_label_set_text (GTK_LABEL (data), "Welcome to APISTRAT");
+    GtkWidget *label = user_data;
+    gtk_label_set_text (GTK_LABEL (label), "Welcome to APISTRAT");
 }
 
 int main (int argc, char* argv[])
@@ -15,11 +16,11 @@ int main (int argc, char* argv[])
     gtk_window_set_default_size (GTK_WINDOW (window), 300, 200);
     gtk_window_set_title (GTK_WINDOW (window), "Linux Foundation");
     gtk_container_set_border_width (GTK_CONTAINER (window), 50);
-      
+
     button = gtk_button_new_with_label ("Click me");
     gtk_widget_set_halign (button, GTK_ALIGN_START);
     gtk_widget_set_valign (button, GTK_ALIGN_START);
-      
+
     label = gtk_label_new (NULL);
     gtk_widget_set_halign (label, GTK_ALIGN_END);
     gtk_widget_set_valign (label, GTK_ALIGN_END);
@@ -28,7 +29,7 @@ int main (int argc, char* argv[])
     gtk_box_pack_start (GTK_BOX (box), button, TRUE, TRUE, 0);
     gtk_box_pack_start (GTK_BOX (box), label, TRUE, TRUE, 0);
     gtk_container_add (GTK_CONTAINER (window), box);
-      
+
     g_signal_connect (window, "destroy", G_CALLBACK (gtk_main_quit), NULL);
     g_signal_connect (button, "clicked", G_CALLBACK (on_button_clicked), label);
 

--- a/StartingGTK_C/window08.c
+++ b/StartingGTK_C/window08.c
@@ -1,8 +1,9 @@
 #include <gtk/gtk.h>
 
-static void on_button_clicked (GtkWidget *widget, gpointer data)
+static void on_button_clicked (GtkButton *button, gpointer user_data)
 {
-    g_print ("%s\n", gtk_entry_get_text (GTK_ENTRY (data)));
+    GtkWidget *entry = user_data;
+    g_print ("%s\n", gtk_entry_get_text (GTK_ENTRY (entry)));
 }
 
 int main (int argc, char *argv[])
@@ -26,7 +27,7 @@ int main (int argc, char *argv[])
 
     g_signal_connect (window, "destroy", G_CALLBACK (gtk_main_quit), NULL);
     g_signal_connect (button, "clicked", G_CALLBACK (on_button_clicked), entry);
-    
+
     gtk_widget_show_all (window);
     gtk_main ();
     return 0;

--- a/StartingGTK_C/window09.c
+++ b/StartingGTK_C/window09.c
@@ -1,7 +1,8 @@
 #include <gtk/gtk.h>
 
-static void on_entry_activate (GtkEntry *entry, GtkLabel *label)
+static void on_entry_activate (GtkEntry *entry, gpointer user_data)
 {
+    GtkLabel *label = user_data;
     gtk_label_set_text (GTK_LABEL (label), gtk_entry_get_text (GTK_ENTRY (entry)));
 }
 


### PR DESCRIPTION
Signals have a well defined signature that needs to be respected.
The best way for beginners to not mess up is to respect the exact
signature of a signal as stated in the documentation, then cast
the parameters when needed.